### PR TITLE
Enable Java in Safari

### DIFF
--- a/rtrouton_scripts/enable_java_web_plugins_at_login/enable_web_java_plugin.sh
+++ b/rtrouton_scripts/enable_java_web_plugins_at_login/enable_web_java_plugin.sh
@@ -14,3 +14,10 @@ fi
 /usr/libexec/PlistBuddy -c "Add :GeneralByTask:Any:WebComponentsEnabled bool true" /Users/$USER/Library/Preferences/ByHost/com.apple.java.JavaPreferences.${MAC_UUID}.plist
 /usr/libexec/PlistBuddy -c "Delete :GeneralByTask:Any:WebComponentsLastUsed" /Users/$USER/Library/Preferences/ByHost/com.apple.java.JavaPreferences.${MAC_UUID}.plist
 /usr/libexec/PlistBuddy -c "Add :GeneralByTask:Any:WebComponentsLastUsed real $(( $(date "+%s") - 978307200 ))" /Users/$USER/Library/Preferences/ByHost/com.apple.java.JavaPreferences.${MAC_UUID}.plist
+
+# Configure Safari to enable Java by default.
+
+/usr/libexec/PlistBuddy -c "Delete :WebKitJavaEnabled" /Users/$USER/Library/Preferences/com.apple.Safari.plist
+/usr/libexec/PlistBuddy -c "Add :WebKitJavaEnabled bool true" /Users/$USER/Library/Preferences/com.apple.Safari.plist
+/usr/libexec/PlistBuddy -c "Delete :WebKit2JavaEnabled" /Users/$USER/Library/Preferences/com.apple.Safari.plist
+/usr/libexec/PlistBuddy -c "Add :WebKit2JavaEnabled bool true" /Users/$USER/Library/Preferences/com.apple.Safari.plist


### PR DESCRIPTION
Your script successfully enables Java at login, but it appears Apple has decided to disable Java in Safari by default (see screen shot on Chris Gerke's blog: http://www.randomsquared.com/post/27101277396). So, while Java becomes enabled and works for every other browser, Safari has it disabled even with this script.

I just added in a few PlistBuddy commands to enable Safari's Java for the logging in user. Works well in my environment.
