### PR TITLE
change to bash and use [[ vs [ - see extended

### DIFF
--- a/rtrouton_scripts/xprotect_re-enable_java_6_and_7/xprotect_re-enable_java_6_and_7.sh
+++ b/rtrouton_scripts/xprotect_re-enable_java_6_and_7/xprotect_re-enable_java_6_and_7.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script will check the current Java 6 and Java 7 browser plug-in
 # versions and compare them against the minimum version allowed by
@@ -30,7 +30,7 @@ XPROTECT_JAVA_7_BUILD=`/usr/libexec/PlistBuddy -c "print :PlugInBlacklist:10:com
 
 if [[ -e /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/XProtect.meta.plist ]]; then
 	
-	if [ ${CURRENT_JAVA_6_BUILD} != ${XPROTECT_JAVA_6_BUILD} ]; then
+	if [[ ${CURRENT_JAVA_6_BUILD} != ${XPROTECT_JAVA_6_BUILD} ]]; then
 
 	 	  /usr/bin/logger "Current Java 6 build (${CURRENT_JAVA_6_BUILD}) does not match the minimum build required by Xprotect (${XPROTECT_JAVA_6_BUILD}). Setting current version as the minimum build."
 	 	  /usr/bin/defaults write /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/XProtect.meta JavaWebComponentVersionMinimum -string "$CURRENT_JAVA_6_BUILD"
@@ -50,8 +50,8 @@ if [[ -e /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/XProte
 # 
    
     if [[ ${osvers} -ge 7 ]]; then
-      if [ "$javaVendor" = "com.oracle.java.JavaAppletPlugin" ]; then 
-	 	if [ ${CURRENT_JAVA_7_BUILD} != ${XPROTECT_JAVA_7_BUILD} ]; then
+      if [[ "$javaVendor" = "com.oracle.java.JavaAppletPlugin" ]]; then 
+	 	if [[ ${CURRENT_JAVA_7_BUILD} != ${XPROTECT_JAVA_7_BUILD} ]]; then
 
 	 	  /usr/bin/logger "Current Java 7 build (${CURRENT_JAVA_7_BUILD}) does not match the minimum build required by Xprotect (${XPROTECT_JAVA_7_BUILD}). Setting current version as the minimum build."
 	 	  /usr/libexec/PlistBuddy -c "Set :PlugInBlacklist:10:com.oracle.java.JavaAppletPlugin:MinimumPlugInBundleVersion $CURRENT_JAVA_7_BUILD" /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/XProtect.meta.plist
@@ -63,4 +63,3 @@ if [[ -e /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/XProte
 	  fi
     fi
 fi
-exit 0


### PR DESCRIPTION
If someone has used Greg Neagle's suggestion and deleted the JavaWebComponentVersionMinimum entry from XProtect.meta.plist the above code will result in errors when XPROTECT_JAVA_6_BUILD is empty.

I have documented the behavior in [this commit](https://github.com/rmanly/xprotect_flash_java_fixer/commit/56a5f8e7d18994ab1340246594f0df965e6b35e9) to my own rewrite of the above code. It was the one instance of [ that I overlooked. :(
