### PR TITLE
FIx for 10.9 status, fixed windows line endings

### DIFF
--- a/rtrouton_scripts/filevault_2_encryption_check/scripts_by_third_parties/a.e.van.bochoven/fv_status.sh
+++ b/rtrouton_scripts/filevault_2_encryption_check/scripts_by_third_parties/a.e.van.bochoven/fv_status.sh
@@ -111,8 +111,13 @@ if grep -iq 'Logical Volume Family' $CORESTORAGESTATUS; then
   fi  
 fi
 
+# This section does 10.9-specific checking of the Mac's
+# FileVault 2 status
+if [[ ${osvers} -ge 13 ]]; then
+  CONVERTED=`grep -E "\Conversion \Progress" $CORESTORAGESTATUS | sed -e's/\|//' | awk '{print $3}'`
+fi
 
-# This section does 10.8-specific checking of the Mac's
+# This section does 10.8-10.9 specific checking of the Mac's
 # FileVault 2 status
 if [ "$ENCRYPTIONEXTENTS" = "Yes" ]; then
   grep -E "$EGREP_STRING\Fully Secure" $CORESTORAGESTATUS | sed -e's/\|//' | awk '{print $3}' >> $ENCRYPTSTATUS


### PR DESCRIPTION
Here's the update for my script

Tested in Mavericks, decrypting and encrypting

Line endings were windows line endings? I changed them to unix line endings.
