### PR TITLE
Update com.company.initialsetup.plist

### DIFF
--- a/rtrouton_scripts/first_boot/10.9/com.company.initialsetup.plist
+++ b/rtrouton_scripts/first_boot/10.9/com.company.initialsetup.plist
@@ -6,7 +6,7 @@
   <string>com.company.initialsetup</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/var/first_boot.sh</string>
+    <string>/var/initialsetup.sh</string>
   </array>
   <key>RunAtLoad</key>
   <true/>


### PR DESCRIPTION
LaunchDaemon plist was referencing the "first_boot.sh" filename instead of "initialsetup.sh" which is the name of the script in the 10.9 folder.
