### PR TITLE
Added check to see if NVRAM entry for SIP exists

### DIFF
--- a/rtrouton_scripts/Casper_Extension_Attributes/check_system_integrity_protection_status/check_system_integrity_protection_status.sh
+++ b/rtrouton_scripts/Casper_Extension_Attributes/check_system_integrity_protection_status/check_system_integrity_protection_status.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-osvers_major=$(sw_vers -productVersion | awk -F. '{print $1}')
-osvers_minor=$(sw_vers -productVersion | awk -F. '{print $2}')
+osvers_major=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F. '{print $1}')
+osvers_minor=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F. '{print $2}')
 
 # Checks to see if the OS on the Mac is 10.x.x. If it is not, the 
 # following message is displayed without quotes:
@@ -9,7 +9,7 @@ osvers_minor=$(sw_vers -productVersion | awk -F. '{print $2}')
 # "Unknown Version Of Mac OS X"
 
 if [[ ${osvers_major} -ne 10 ]]; then
-  /bin/echo "<result>Unknown Version of Mac OS X</result>"
+    /bin/echo "<result>Unknown Version of Mac OS X</result>"
 fi
 
 # Checks to see if the OS on the Mac is 10.11.x or higher.
@@ -18,7 +18,7 @@ fi
 # "System Integrity Protection Not Available For" followed by the version of OS X.
 
 if [[ ${osvers_major} -eq 10 ]] && [[ ${osvers_minor} -lt 11 ]]; then
-  /bin/echo "<result>System Integrity Protection Not Available For `sw_vers -productVersion`</result>"
+    /bin/echo "<result>System Integrity Protection Not Available For $(/usr/bin/sw_vers -productVersion)</result>"
 fi
 
 if [[ ${osvers_major} -eq 10 ]] && [[ ${osvers_minor} -ge 11 ]]; then
@@ -26,46 +26,51 @@ if [[ ${osvers_major} -eq 10 ]] && [[ ${osvers_minor} -ge 11 ]]; then
 # Checks System Integrity Protection status on Macs
 # running 10.11.x or higher
 
-  SIP_status=`/usr/bin/csrutil status | awk '/status/ {print $5}' | sed 's/\.$//'`
+    SIP_status=$(/usr/bin/csrutil status | /usr/bin/awk '/status/ {print $5}' | /usr/bin/sed 's/\.$//')
 
-  if [ $SIP_status = "disabled" ]; then
-      result=Disabled
-  elif [ $SIP_status = "enabled" ]; then
-         SIP_status="Active"
+    # Check if SIP is disabled AND has an entry in nvram which indicates SIP is clearly not enabled
+    if [[ "$SIP_status" = "disabled" ]] && [[ "$(/usr/sbin/nvram -p | /usr/bin/grep "csr-active-config")" ]]; then
+        result="Disabled"
+    # Check if SIP is disabled AND has NO entry in nvram which indicates SIP has been reset to enabled
+    # But needs to be restarted before change takes effect
+    elif [[ "$SIP_status" = "disabled" ]] && [[ -z "$(/usr/sbin/nvram -p | /usr/bin/grep "csr-active-config")" ]]; then
+        result="Set To Enable After Restart"
+    elif [[ "$SIP_status" = "enabled" ]]; then
+        SIP_status="Active"
        
-       # If SIP is enabled, run 'csrutil status' a second time
-       # and export the output to a text file with a randomly
-       # generated name.
+        # If SIP is enabled, run 'csrutil status' a second time
+        # and export the output to a text file with a randomly
+        # generated name.
        
-       sip_output="/tmp/`/usr/bin/uuidgen`.txt"
-      /usr/bin/csrutil status > "$sip_output"
+        sip_output="/tmp/$(/usr/bin/uuidgen).txt"
+        /usr/bin/csrutil status > "$sip_output"
       
-      # Check the exported text file to see any custom SIP configuration
-      # options have been enabled. If any custom SIP configurations are
-      # active, display the configuration status.
+        # Check the exported text file to see any custom SIP configuration
+        # options have been enabled. If any custom SIP configurations are
+        # active, display the configuration status.
       
-      sip_kernel_extension_allowed=`cat "$sip_output" | grep -io "Kext Signing: disabled"`
-        if [[ ${sip_kernel_extension_allowed} != "" ]]; then
-            sip_kernel=`/usr/bin/printf "\n$sip_kernel_extension_allowed"`
+        sip_kernel_extension_allowed=$(/bin/cat "$sip_output" | /usr/bin/grep -io "Kext Signing: disabled")
+        if [[ "${sip_kernel_extension_allowed}" != "" ]]; then
+            sip_kernel=$(/usr/bin/printf "\n$sip_kernel_extension_allowed")
         fi
-      sip_filesystem_allowed=`cat "$sip_output" | grep -io "Filesystem Protections: disabled"`
-        if [[ ${sip_filesystem_allowed} != "" ]]; then
-            sip_filesystem=`/usr/bin/printf "\n$sip_filesystem_allowed"`
+        sip_filesystem_allowed=$(/bin/cat "$sip_output" | /usr/bin/grep -io "Filesystem Protections: disabled")
+        if [[ "${sip_filesystem_allowed}" != "" ]]; then
+            sip_filesystem=$(/usr/bin/printf "\n$sip_filesystem_allowed")
         fi
-      sip_nvram_allowed=`cat "$sip_output" | grep -io "NVRAM Protections: disabled"`
-        if [[ ${sip_nvram_allowed} != "" ]]; then
-            sip_nvram=`/usr/bin/printf "\n$sip_nvram_allowed"`
+        sip_nvram_allowed=$(/bin/cat "$sip_output" | /usr/bin/grep -io "NVRAM Protections: disabled")
+        if [[ "${sip_nvram_allowed}" != "" ]]; then
+            sip_nvram=$(/usr/bin/printf "\n$sip_nvram_allowed")
         fi
-      sip_debug_allowed=`cat "$sip_output" | grep -io "Debugging Restrictions: disabled"`
-        if [[ ${sip_debug_allowed} != "" ]]; then
-            sip_debug=`/usr/bin/printf "\n$sip_debug_allowed"`
+        sip_debug_allowed=$(/bin/cat "$sip_output" | /usr/bin/grep -io "Debugging Restrictions: disabled")
+        if [[ "${sip_debug_allowed}" != "" ]]; then
+            sip_debug=$(/usr/bin/printf "\n$sip_debug_allowed")
         fi
-      sip_dtrace_allowed=`cat "$sip_output" | grep -io "DTrace Restrictions: disabled"`
-        if [[ ${sip_dtrace_allowed} != "" ]]; then
-            sip_dtrace=`/usr/bin/printf "\n$sip_dtrace_allowed"`
+        sip_dtrace_allowed=$(/bin/cat "$sip_output" | /usr/bin/grep -io "DTrace Restrictions: disabled")
+        if [[ "${sip_dtrace_allowed}" != "" ]]; then
+            sip_dtrace=$(usr/bin/printf "\n$sip_dtrace_allowed")
         fi
         if [[ -e "$sip_output" ]]; then
-            /bin/rm "$sip_output"
+            /bin/rm -f "$sip_output"
         fi
         result="$SIP_status$sip_kernel$sip_filesystem$sip_nvram$sip_debug$sip_dtrace"
   fi


### PR DESCRIPTION
Previously you were checking only for `csrutil status`. However it is possible now that SIP has been reset (re-enabled) using the `csrutil clear` command, but that the computer has not been restarted. In that situation, the status will still show SIP as disabled, but if you check NVRAM you will see that there is no entry for "csr-active-config". This would indicate that SIP is set to be enabled after a restart. This is relatively new with 10.12.2.

https://onemoreadmin.wordpress.com/2016/12/13/system-integrity-protection-sip-changes-in-macos-sierra-10-12-2/