### PR TITLE
Update install_xcode_command_line_tools.sh

### DIFF
--- a/rtrouton_scripts/install_xcode_command_line_tools/install_xcode_command_line_tools.sh
+++ b/rtrouton_scripts/install_xcode_command_line_tools/install_xcode_command_line_tools.sh
@@ -17,9 +17,9 @@ if [[ "$osx_vers" -ge 9 ]]; then
 	# Identify the correct update in the Software Update feed with "Command Line Tools" in the name for the OS version in question.
 	
 	if [[ "$osx_vers" -gt 9 ]]; then
-	   cmd_line_tools=$(softwareupdate -l | awk '/\*\ Command Line Tools/ { $1=$1;print }' | grep "$osx_vers" | sed 's/^[[ \t]]*//;s/[[ \t]]*$//;s/*//' | cut -c 2-)
+	   cmd_line_tools=$(softwareupdate -l | awk '/\*\ Command Line Tools/ { $1=$1;print }' | grep "$osx_vers" | sed 's/^[[ \t]]*//;s/[[ \t]]*$//;s/*//' | cut -c 2- | tail -n1)
 	elif [[ "$osx_vers" -eq 9 ]]; then
-	   cmd_line_tools=$(softwareupdate -l | awk '/\*\ Command Line Tools/ { $1=$1;print }' | grep "Mavericks" | sed 's/^[[ \t]]*//;s/[[ \t]]*$//;s/*//' | cut -c 2-)
+	   cmd_line_tools=$(softwareupdate -l | awk '/\*\ Command Line Tools/ { $1=$1;print }' | grep "Mavericks" | sed 's/^[[ \t]]*//;s/[[ \t]]*$//;s/*//' | cut -c 2- | tail -n1)
 	fi
 	
 	#Install the command line tools


### PR DESCRIPTION
Sometimes softwareupdate can have more than one verion of command line tools available

```
root# softwareupdate -l
Software Update Tool
Copyright 2002-2015 Apple Inc.

Finding available software
Software Update found the following new or updated software:
   * Command Line Tools (macOS Sierra version 10.12) for Xcode-8.1
	Command Line Tools (macOS Sierra version 10.12) for Xcode (8.1), 123638K [recommended]
   * Command Line Tools (macOS Sierra version 10.12) for Xcode-8.2
	Command Line Tools (macOS Sierra version 10.12) for Xcode (8.2), 150550K [recommended]
```

This can lead to unwanted behaviour, as the following argument is passed to `softwareupdate -i`
```
root# echo $cmd_line_tools
Command Line Tools (macOS Sierra version 10.12) for Xcode-8.1 Command Line Tools (macOS Sierra version 10.12) for Xcode-8.2
```

This pull requests only selects the last (newest) entry. Avoiding that problem.