### PR TITLE
Update install_company_canon_printer_drivers.sh

### DIFF
--- a/rtrouton_scripts/Casper_Scripts/install_company_canon_printer_drivers/install_company_canon_printer_drivers.sh
+++ b/rtrouton_scripts/Casper_Scripts/install_company_canon_printer_drivers/install_company_canon_printer_drivers.sh
@@ -7,31 +7,30 @@ osvers=$(sw_vers -productVersion | awk -F. '{print $2}')
 # for the CFBundleVersion key value. It should match the version of the installed drivers.
 
 installed_driver=$(defaults read "/Library/Printers/Canon/CUPSPS2/Utilities/Canon CUPS PS Printer Utility.app/Contents/Info" CFBundleVersion)
+installed_driver_int=$(python -c 'import sys;print sys.argv[1].replace(".","")' "$installed_driver")
 
 # Specify the current driver version
 # by setting parameter 4 in the script
 # on the JSS
 
 driver_version="$4"
-dialog="The needed Canon printer drivers have not been detected. Installing Canon PS $driver_version Print Drivers before adding the requested printer."
+driver_version_int=$(python -c 'import sys;print sys.argv[1].replace(".","")' "$driver_version")
+
+dialog="The needed Canon printer drivers have not been detected. Installing Canon PS $driver_version Print Drivers before adding the requested printer. This may take a moment."
 description=$(echo "$dialog")
 button1="OK"
 jamfHelper="/Library/Application Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper"
 icon="/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertNoteIcon.icns"
 
-if [ $installed_driver > $driver_version ]; then
-  echo "Canon PS $installed_driver Print Drivers installed"
-fi
-
-if [ $installed_driver == $driver_version ]; then
-  echo "Canon PS $driver_version Print Drivers installed"
-fi
-
-if [ $installed_driver < $driver_version ]; then
-  echo "Canon PS $driver_version Print Drivers not installed. Installing Canon PS $driver_version Print Drivers"
+if [[ ${installed_driver_int} -gt ${driver_version_int} ]]; then
+  echo "Canon PS $installed_driver Print Drivers installed."
+elif [[ ${installed_driver_int} -eq ${driver_version_int} ]]; then
+  echo "Canon PS $driver_version Print Drivers installed."
+elif [[ ${installed_driver_int} -lt ${driver_version_int} ]]; then
+  echo "Canon PS $driver_version not found or drivers are not installed. Installing Canon PS $driver_version Print Drivers."
   if [[ ${osvers} -lt 7 ]]; then
 
-    "$jamfHelper" -windowType utility -description "$description" -button1 "$button1" -icon "$icon" -timeout 20
+    "$jamfHelper" -windowType utility -description "$description" -button1 "$button1" -icon "$icon" -timeout 10
 
   fi
 
@@ -40,7 +39,7 @@ if [ $installed_driver < $driver_version ]; then
     jamf displayMessage -message "$dialog"
 
   fi
- jamf policy -trigger companycanondrivers
+ jamf policy -event companycanondrivers
 fi
 
 exit 0


### PR DESCRIPTION
Another batch of small tweaks:
1. get version numbers with dots removed so that the gt/lt/eq are honored when the versioning inside the dots goes to double-digits (e.g., 4.9.0 vs 4.11.0) (lines 10 and 17)
2. made multiple if statements into if/elif statements
3. Minor tweak to echo in line 30
4. Changed legacy -trigger to current -event in line 42
5. Change legacy `..` to $(..) in line 20

Confirmed that version checking now works as expected and drivers will install if there are no drivers found.