### PR TITLE
Ensure mobile users get a Password attribute when converting to local.

### DIFF
--- a/rtrouton_scripts/migrate_ad_mobile_account_to_local_account/MigrateADMobileAccounttoLocalAccount.command
+++ b/rtrouton_scripts/migrate_ad_mobile_account_to_local_account/MigrateADMobileAccounttoLocalAccount.command
@@ -176,6 +176,10 @@ until [ "$user" == "FINISHED" ]; do
 			/usr/bin/dscl . -delete /users/$netname MCXSettings
 			/usr/bin/dscl . -delete /users/$netname MCXFlags
 
+			# Ensure the user has a Password attribute
+
+			/usr/bin/dscl . -create /Users/$netname Password '********'
+
 			# Refresh Directory Services
 			if [[ ${osvers} -ge 7 ]]; then
 				/usr/bin/killall opendirectoryd


### PR DESCRIPTION
Some mobile accounts don't have a `Password` attribute set to `********`. If they are converted to local accounts the High Sierra OS installer will change the `ShadowHashData` and `AuthenticationAuthority` attributes during an upgrade, locking users out.

Please note that I don't have our environment set up to test a full AD migration and OS upgrade from start to finish, but I have tested the individual steps in a VM.