### PR TITLE
Fixed "ls" error with PolicyDownloadDirectory

### DIFF
--- a/rtrouton_scripts/Casper_Scripts/Jamf_Pro_Computer_Policy_Download/Jamf_Pro_Computer_Policy_Download.sh
+++ b/rtrouton_scripts/Casper_Scripts/Jamf_Pro_Computer_Policy_Download/Jamf_Pro_Computer_Policy_Download.sh
@@ -121,7 +121,7 @@ else
    # Remove the trailing slash from the PolicyDownloadDirectory variable if needed.
    PolicyDownloadDirectory=${PolicyDownloadDirectory%%/}
 
-   if [[ -d "$PolicyDownloadDirectory" ]] && [[ -n "$(ls -A $PolicyDownloadDirectory)" ]]; then
+   if [[ -d "$PolicyDownloadDirectory" ]] && [[ -n "$(ls -A "$PolicyDownloadDirectory")" ]]; then
 		archive_file="PolicyDownloadDirectoryArchive-`date +%Y%m%d%H%M%S`.zip"
 		echo "Archiving previous policy download directory to ${PolicyDownloadDirectory%/*}/$archive_file"
 		ditto -ck "$PolicyDownloadDirectory" "${PolicyDownloadDirectory%/*}/$archive_file"


### PR DESCRIPTION
Line 124 would cause an error  if the path had spaces. Wrapped the variable in quotes to fix.