### PR TITLE
Add step to script to retry download of Policy ID List if first download failed

### DIFF
--- a/rtrouton_scripts/Casper_Scripts/Jamf_Pro_Detect_Self_Service_Policies_Without_Icons/Jamf_Pro_Detect_Self_Service_Policies_Without_Icons.sh
+++ b/rtrouton_scripts/Casper_Scripts/Jamf_Pro_Detect_Self_Service_Policies_Without_Icons/Jamf_Pro_Detect_Self_Service_Policies_Without_Icons.sh
@@ -91,6 +91,10 @@ CheckSelfServicePolicyCheckIcons(){
 # Download all Jamf Pro policy ID numbers
 
 PolicyIDList=$(curl -su "${jamfpro_user}:${jamfpro_password}" -H "Accept: application/xml" "${jamfpro_url}/JSSResource/policies" | xpath "//id" 2>/dev/null)
+if [ -z "$PolicyIDList" ]; then
+echo "WARNING:No Policy ID List downloaded, trying again without validating SSL security certificate."
+PolicyIDList=$(curl -ksu "${jamfpro_user}:${jamfpro_password}" -H "Accept: application/xml" "${jamfpro_url}/JSSResource/policies" | xpath "//id" 2>/dev/null)
+fi
 PolicyIDs=$(echo "$PolicyIDList" | grep -Eo "[0-9]+")
 PoliciesCount=$(echo "$PolicyIDs" | grep -c ^)
 


### PR DESCRIPTION
Added a check to your Jamf_Pro_Detect_Self_Service_Policies_Without_Icons.sh script to check if the Policy ID List download was blank and if so try again without validating the SSL cert and notify the script user as such.