### PR TITLE
fix typo in install_xcode_command_line_tools.sh

### DIFF
--- a/rtrouton_scripts/install_xcode_command_line_tools/install_xcode_command_line_tools.sh
+++ b/rtrouton_scripts/install_xcode_command_line_tools/install_xcode_command_line_tools.sh
@@ -61,7 +61,7 @@ fi
 
 if [[ ( ${osvers_major} -eq 10 && ${osvers_minor} -eq 7 ) || ( ${osvers_major} -eq 10 && ${osvers_minor} -eq 8 ) ]]; then
 
-	q	
+	if [[ ( ${osvers_major} -eq 10 && ${osvers_minor} -eq 7 ) ]]; then	
 	    DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_xcode_os_x_lion_april_2013.dmg
 	fi
 	


### PR DESCRIPTION
My eye fell on an accidental replacement of a line, so I put the line back as I think it should be. I've not tested it though (I've no access anymore to OS X Lion).