### PR TITLE
updated how to check if Rosetta is installed.

### DIFF
--- a/rtrouton_scripts/install_rosetta_on_apple_silicon/install_rosetta_on_apple_silicon.sh
+++ b/rtrouton_scripts/install_rosetta_on_apple_silicon/install_rosetta_on_apple_silicon.sh
@@ -22,7 +22,7 @@ if [[ ${osvers_major} -ge 11 ]]; then
   # Check to see if the Mac needs Rosetta installed by testing the processor
 
   processor=$(/usr/sbin/sysctl -n machdep.cpu.brand_string | grep -o "Intel")
-  ​
+  
   if [[ -n "$processor" ]]; then
     echo "$processor processor installed. No need to install Rosetta."
   else

--- a/rtrouton_scripts/install_rosetta_on_apple_silicon/install_rosetta_on_apple_silicon.sh
+++ b/rtrouton_scripts/install_rosetta_on_apple_silicon/install_rosetta_on_apple_silicon.sh
@@ -27,12 +27,10 @@ if [[ ${osvers_major} -ge 11 ]]; then
     echo "$processor processor installed. No need to install Rosetta."
   else
 
-    # Check for an installer receipt for Rosetta. If no receipt is found,
+    # Check Rosetta LaunchDaemon. If no LaunchDaemon is found,
     # perform a non-interactive install of Rosetta.
-   
-    rosetta_check=$(/usr/sbin/pkgutil --pkgs | grep "com.apple.pkg.RosettaUpdateAuto")
-
-    if [[ -z "$rosetta_check" ]]; then
+    
+    if [[ ! -f "/System/Library/LaunchDaemons/com.apple.oahd.plist" ]]; then
         /usr/sbin/softwareupdate --install-rosetta --agree-to-license
        
         if [[ $? -eq 0 ]]; then

--- a/rtrouton_scripts/install_rosetta_on_apple_silicon/install_rosetta_on_apple_silicon.sh
+++ b/rtrouton_scripts/install_rosetta_on_apple_silicon/install_rosetta_on_apple_silicon.sh
@@ -30,7 +30,7 @@ if [[ ${osvers_major} -ge 11 ]]; then
     # Check Rosetta LaunchDaemon. If no LaunchDaemon is found,
     # perform a non-interactive install of Rosetta.
     
-    if [[ ! -f "/System/Library/LaunchDaemons/com.apple.oahd.plist" ]]; then
+    if [[ ! -f "/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist" ]]; then
         /usr/sbin/softwareupdate --install-rosetta --agree-to-license
        
         if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
If Rosetta 2 gets uninstalled, there's a chance the receipt is still there as observed when having R2 installed on macOS 11.0.0 and upgrading to 11.0.1. This new method checks if the R2 LaunchDaemon exists instead of the package receipt.