### PR TITLE
Add CoreTypes Package

### DIFF
--- a/rtrouton_scripts/xcode_post_install_actions/xcode_post_install_actions.sh
+++ b/rtrouton_scripts/xcode_post_install_actions/xcode_post_install_actions.sh
@@ -43,4 +43,10 @@ if [[ -e "/Applications/Xcode.app/Contents/Resources/Packages/XcodeSystemResourc
   /usr/sbin/installer -dumplog -verbose -pkg "/Applications/Xcode.app/Contents/Resources/Packages/XcodeSystemResources.pkg" -target /
 fi
 
+# Install Xcode CoreTypes Package, available in Xcode 14 and later
+
+if [[ -e "/Applications/Xcode.app/Contents/Resources/Packages/CoreTypes.pkg" ]]; then
+  /usr/sbin/installer -dumplog -verbose -pkg "/Applications/Xcode.app/Contents/Resources/Packages/CoreTypes.pkg" -target /
+fi
+
 exit 0


### PR DESCRIPTION
Added CoreTypes Package on lines 48-50. Without this, it will require admin credentials for Xcode 14.